### PR TITLE
Upgrading to OpenSearch 1.3.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,8 @@ on:
       - "6.x"
 
 env:
-  gradle-version: "7.0.2"
-  java-version: "16"
+  gradle-version: "6.9.2"
+  java-version: "11"
 
 jobs:
   build:

--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,12 @@ validatePom.enabled = false
 // No unit tests in this plugin
 test.enabled = false
 
+dependencyLicenses.enabled = false
+loggerUsageCheck.enabled = false
+testingConventions.enabled = false
+thirdPartyAudit.enabled = false
+validateNebulaPom.enabled = false
+
 println "Host: " + java.net.InetAddress.getLocalHost()
 println "Gradle: " + gradle.gradleVersion + " JVM: " + org.gradle.internal.jvm.Jvm.current() + " Groovy: " + GroovySystem.getVersion()
 println "Build: group: '${project.group}', name: '${project.name}', version: '${project.version}'"
@@ -68,7 +74,7 @@ ext {
         "opensearch": es_version,
         "prometheus"   : "0.8.0",
         "log4j"        : "2.17.1",
-        "junit"        : "4.12"
+        "junit"        : "4.13.2"
     ]
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 group = org.opensearch.plugin.prometheus
 
-version = 1.2.4
+version = 1.3.1
 
 pluginName = prometheus-exporter
 pluginClassname = org.opensearch.plugin.prometheus.PrometheusExporterPlugin


### PR DESCRIPTION
When upgrading to the latest the OpenSearch helm chart (1.10.2), getting this error:

```
-> Installing https://github.com/aparo/opensearch-prometheus-exporter/releases/download/1.2.4/prometheus-exporter-1.2.4.zip
-> Downloading https://github.com/aparo/opensearch-prometheus-exporter/releases/download/1.2.4/prometheus-exporter-1.2.4.zip
-> Failed installing https://github.com/aparo/opensearch-prometheus-exporter/releases/download/1.2.4/prometheus-exporter-1.2.4.zip
-> Rolling back https://github.com/aparo/opensearch-prometheus-exporter/releases/download/1.2.4/prometheus-exporter-1.2.4.zip
-> Rolled back https://github.com/aparo/opensearch-prometheus-exporter/releases/download/1.2.4/prometheus-exporter-1.2.4.zip
Exception in thread "main" java.lang.IllegalArgumentException: Plugin [prometheus-exporter] was built for OpenSearch version 1.2.4 but version 1.3.1 is running
        at org.opensearch.plugins.PluginsService.verifyCompatibility(PluginsService.java:392)
        at org.opensearch.plugins.InstallPluginCommand.loadPluginInfo(InstallPluginCommand.java:815)
        at org.opensearch.plugins.InstallPluginCommand.installPlugin(InstallPluginCommand.java:870)
        at org.opensearch.plugins.InstallPluginCommand.execute(InstallPluginCommand.java:275)
        at org.opensearch.plugins.InstallPluginCommand.execute(InstallPluginCommand.java:249)
        at org.opensearch.cli.EnvironmentAwareCommand.execute(EnvironmentAwareCommand.java:100)
        at org.opensearch.cli.Command.mainWithoutErrorHandling(Command.java:138)
        at org.opensearch.cli.MultiCommand.execute(MultiCommand.java:104)
        at org.opensearch.cli.Command.mainWithoutErrorHandling(Command.java:138)
        at org.opensearch.cli.Command.main(Command.java:101)
        at org.opensearch.plugins.PluginCli.main(PluginCli.java:60)
```

Hoping simply bumping the version for the gradle build is all thats required. Will comment on this PR with the results of my initial testing.